### PR TITLE
Remove unneeded 'syntax on' call

### DIFF
--- a/start-vimtutor.vim
+++ b/start-vimtutor.vim
@@ -1,6 +1,5 @@
 set nocompatible
 filetype plugin indent on
-syntax on
 hi! link Conceal Operator
 hi! link FoldColumn Comment
 hi! link SignColumn Normal


### PR DESCRIPTION
Already in 'autoload/tutor.vim'

Not sure if this is actually needed...